### PR TITLE
Fix market data subscription cancellation

### DIFF
--- a/ES/agg_port_live.py
+++ b/ES/agg_port_live.py
@@ -416,7 +416,7 @@ def place_limit_order(ib, contract, action, quantity, symbol):
         current_price = (ticker.bid + ticker.ask) / 2
     
     # Cancel market data subscription
-    ib.cancelMktData(contract)
+    ib.cancelMktData(ticker)
     
     if current_price:
         # Set limit price slightly favorable (0.1% buffer)


### PR DESCRIPTION
## Summary
- capture ticker from `ib.reqMktData`
- cancel market data using returned ticker

## Testing
- `python -m py_compile ES/agg_port_live.py`

------
https://chatgpt.com/codex/tasks/task_e_684f1683a41c8330a34ae970ccea0641